### PR TITLE
Restyle Nostrum components via Tamagui; prepare v0.0.3

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,7 +17,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "arcade.labs.arc",
-      "buildNumber": "1",
+      "buildNumber": "2",
       "config": {
         "usesNonExemptEncryption": false
       }
@@ -27,7 +27,7 @@
         "foregroundImage": "./src/assets/icons/adaptive-icon.png",
         "backgroundColor": "#000000"
       },
-      "versionCode": 9
+      "versionCode": 10
     },
     "extra": {
       "eas": {

--- a/app.json
+++ b/app.json
@@ -27,7 +27,7 @@
         "foregroundImage": "./src/assets/icons/adaptive-icon.png",
         "backgroundColor": "#000000"
       },
-      "versionCode": 10
+      "versionCode": 11
     },
     "extra": {
       "eas": {

--- a/src/navigation/AuthedNavigator.tsx
+++ b/src/navigation/AuthedNavigator.tsx
@@ -22,7 +22,7 @@ export function AuthedNavigator() {
   useRelayPool({ connectNow: true })
   return (
     <Stack.Navigator
-      initialRouteName="firstload"
+      initialRouteName="tabs"
       screenOptions={{
         header: ({ options }) => (
           <NavHeader options={options} title={options.title} />

--- a/src/views/connect/components/Layout.tsx
+++ b/src/views/connect/components/Layout.tsx
@@ -9,7 +9,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
 const styles = StyleSheet.create({
   center: {
     flex: 1,
-    backgroundColor: darkBlue,
+    backgroundColor: 'transparent',
     paddingTop: 32,
   },
 })

--- a/src/views/connect/nostrum/ConnectList.tsx
+++ b/src/views/connect/nostrum/ConnectList.tsx
@@ -101,8 +101,6 @@ export default function ConnectList({ navigation }: { navigation: any }) {
       const store = useStore.getState() as UseStore
       const key = store.user.privateKey
 
-      console.log('We have key?', key)
-
       if (!key) return
 
       // set the pub key
@@ -344,17 +342,6 @@ export default function ConnectList({ navigation }: { navigation: any }) {
           <View style={{ flexDirection: 'row', justifyContent: 'center' }}>
             <View style={{ justifyContent: 'center' }}>
               <Text style={styles.title}>Connected Apps</Text>
-            </View>
-            <View
-              style={{
-                marginLeft: 'auto',
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            >
-              <TouchableOpacity onPress={keyInfoPress} style={styles.button}>
-                <Text style={{ fontSize: 32 }}>🔑</Text>
-              </TouchableOpacity>
             </View>
           </View>
           {apps === null || apps.length === 0 ? (
@@ -607,13 +594,13 @@ const styles = StyleSheet.create({
   },
   title: {
     fontSize: 24,
-    // fontFamily: 'SoraBold',
-    marginVertical: 24,
+    fontFamily: 'InterBold',
+    marginBottom: 24,
     color: '#fff',
   },
   text: {
     fontSize: 16,
-    // fontFamily: 'SoraRegular',
+    fontFamily: 'Inter',
     marginBottom: 8,
     color: '#fff',
     textAlign: 'center',
@@ -627,7 +614,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     padding: 16,
-    backgroundColor: darkBlue,
+    backgroundColor: 'transparent',
     borderTopLeftRadius: 8,
     borderTopRightRadius: 8,
     borderBottomLeftRadius: 8,


### PR DESCRIPTION
On Android we skip past the FirstLoad screen (removing that in next version) 

![androidcon](https://user-images.githubusercontent.com/14167547/221932827-2256e436-e0ad-49e9-90bc-04ae72f4987a.png)
